### PR TITLE
Fix dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,13 +16,14 @@
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>visualization_marker</build_depend>
+  <build_depend>visualization_msgs</build_depend>
+  <build_depend>libmarble-dev</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_cpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
-  <run_depend>visualization_marker</run_depend>
+  <run_depend>visualization_msgs</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <run_depend>rqt_gui_cpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>
+  <run_depend>libmarble-dev</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
When doing:

    rosdep install rqt_marble_plugin

Got:

    ERROR: the following packages/stacks could not have their rosdep keys resolved to system dependencies:
    rqt_marble_plugin: Cannot locate rosdep definition for [visualization_marker]

Which I believe you wanted to depend on the markers messages.

Then, to compile, I needed to have installed `libmarble-dev`, so I also added it to the build_depend.

Tested on a ubuntu 12.04 32bit system and it worked.